### PR TITLE
When reading model from file, model->sv_indices is null

### DIFF
--- a/src/LibSvmDotNet/Model.cs
+++ b/src/LibSvmDotNet/Model.cs
@@ -40,7 +40,8 @@ namespace LibSvmDotNet
                     this.SupportVectorCoefficients[index] = Copy(model->sv_coef[index], this.L);
             }
 
-            this.SupportVectorIndices = Copy(model->sv_indices, this.L);
+            if (model->sv_indices != null)
+                this.SupportVectorIndices = Copy(model->sv_indices, this.L);
 
             var length = (this.Classes - 1) * this.Classes / 2;
             this.Rho = Copy(model->rho, length);


### PR DESCRIPTION
Attempting to round trip the model to file will fail, as the file does not contain `sv_indices` (see implementation of `svm_load_model`).